### PR TITLE
Fix shell scripts and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # PopGenomics
+
+This repository contains example scripts for common population genomics workflows.
+Each script defines a few variables at the top so you can adjust paths and
+output prefixes to your own dataset.
+
+- `downstream_SNP_filtering.sh`: example filtering steps using `vcftools`.
+- `haplotype_phasing_SHAPEIT.sh`: notes on phasing data with SHAPEIT.

--- a/downstream_SNP_filtering.sh
+++ b/downstream_SNP_filtering.sh
@@ -10,46 +10,30 @@
 #SBATCH --cpus-per-task=6  # number of cpus / threads
 #SBATCH --time=01:00:00    # time
 
-module load perl/5.26.3
-module load gsl/2.5
-module load vcftools
-module load bcftools/1.16
+# Edit these variables for your run
+input_vcf="/path/to/input/file.hf.vcf.gz"
+output_prefix="file"
+
+# Modules required for filtering
+modules=(perl/5.26.3 gsl/2.5 vcftools bcftools/1.16)
+for m in "${modules[@]}"; do
+    module load "$m"
+done
 
 # Keep only SNPs
-vcftools --gzvcf /path/to/input/file.hf.vcf.gz \
---remove-indels --recode --stdout \
-> file.SNP.vcf
+vcftools --gzvcf "$input_vcf" \
+    --remove-indels --recode --stdout \
+    > "${output_prefix}.SNP.vcf"
 
 # And let's do a version keeping only autosomes too (excluding X & Y).
-vcftools --vcf file.SNP.vcf --not-chr chrX --not-chr chrY --recode --stdout > file.SNP.noXY.vcf
-
-
-
-
-
-#----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-#!/bin/bash
-#SBATCH -J lastfilt      ## you can give whatever name you want here to identify your job
-#SBATCH -o lastfilt.log  ## name a file to save log of your job
-#SBATCH -e lastfilt.error   ## save error message if any
-##SBATCH --mail-user=example@example.dk ## your email account to receive notification of job status
-##SBATCH --mail-type=ALL        ## ALL mean you will receive everything about your job, such like start running, fail, or fi$
-#SBATCH -t 01:00:00 ## give an estimation of how long is your job going to run, format HH:MM:SS (1-10 days in this case)
-#SBATCH -c 6   ## number cpus
-#SBATCH --mem=40gb     ## total RAM
-
-module load perl/5.26.3
-module load gsl/2.5
-module load vcftools
-module load bcftools/1.16
+vcftools --vcf "${output_prefix}.SNP.vcf" --not-chr chrX --not-chr chrY --recode --stdout > "${output_prefix}.SNP.noXY.vcf"
 
 # DOWNSTREAM FILTERING
 # MAF, missingness, minimum quality, minmum & maximum number of alleles, minimum & maximum depth (including their mean too).
 # A rule of thumb is to filter minimum/maximum and average minimum/maximum depth based on half/double the coverage of your samples with minimum/maximum coverage respectively.
-vcftools --vcf file.SNP.noXY.vcf \
+vcftools --vcf "${output_prefix}.SNP.noXY.vcf" \
 --maf 0.05 --max-missing 0.9 --minQ 30 \
 --min-alleles 2 --max-alleles 2 \
 --minDP 5 --min-meanDP 5 \
 --maxDP 55 --max-meanDP 55 --recode --stdout \
-> file.SNP.noXY.filt.vcf
+> "${output_prefix}.SNP.noXY.filt.vcf"

--- a/haplotype_phasing_SHAPEIT.sh
+++ b/haplotype_phasing_SHAPEIT.sh
@@ -1,49 +1,56 @@
+#!/bin/bash
 # MAIN PRINCIPLE: the larger the dataset to phase, the higher the phasing quality.
 
+# Input settings
+plink_prefix="file"
+map_file="genetic_map.txt"
+ids_file="file.subset.inds"
+out_prefix="file.phased"
+
 # Haplotype phasing starting from bed/bim/fam (binary PLINK files) using SHAPEIT2.
-shapeit --input-bed file.bed file.bim file.fam \
---input-map genetic_map.txt \
---output-haps file.phased.haps file.phased.sample
+shapeit --input-bed "${plink_prefix}.bed" "${plink_prefix}.bim" "${plink_prefix}.fam" \
+    --input-map "$map_file" \
+    --output-haps "${out_prefix}.haps" "${out_prefix}.sample"
 
 
 #-------------------------------------------------------------------------------------------
 # (if needed) exclude/include individuals to only phase a particular set of samples (.inds -> one column with individual IDs)
 # EXCLUDE
-shapeit --input-bed file \
---input-map genetic_map.txt \
---exclude-ind file.subset.inds \
---output-haps file.phased
+shapeit --input-bed "${plink_prefix}.bed" "${plink_prefix}.bim" "${plink_prefix}.fam" \
+    --input-map "$map_file" \
+    --exclude-ind "$ids_file" \
+    --output-haps "${out_prefix}.exclude"
 
 # INCLUDE
-shapeit --input-bed file \
---input-map genetic_map.txt \
---include-ind file.subset.inds \
---output-haps file.phased
+shapeit --input-bed "${plink_prefix}.bed" "${plink_prefix}.bim" "${plink_prefix}.fam" \
+    --input-map "$map_file" \
+    --include-ind "$ids_file" \
+    --output-haps "${out_prefix}.include"
 
 
 #-------------------------------------------------------------------------------------------
 # SHAPEIT generates .haps file which you may want to convert to other formats.
 shapeit --convert \
---input-haps file.phased \
---output-ref file.phased.hap file.phased.leg file.phased.sam
+    --input-haps "$out_prefix" \
+    --output-ref "${out_prefix}.hap" "${out_prefix}.leg" "${out_prefix}.sam"
 
 # You can also convert to VCF
 shapeit --convert \
---input-haps file.phased \
---output-vcf file.phased.vcf
+    --input-haps "$out_prefix" \
+    --output-vcf "${out_prefix}.vcf"
 
 
 #-------------------------------------------------------------------------------------------
 # You can subset the phased dataset.
 # EXCLUDE
 shapeit --convert \
---input-haps file.phased \
---exclude-ind file.subset.inds \
---output-haps subset.phased
+    --input-haps "$out_prefix" \
+    --exclude-ind "$ids_file" \
+    --output-haps "${out_prefix}.subset"
 
 # INCLUDE
 shapeit --convert \
---input-haps file.phased \
---include-ind file.subset.inds \
---output-haps subset.phased
+    --input-haps "$out_prefix" \
+    --include-ind "$ids_file" \
+    --output-haps "${out_prefix}.subset"
 


### PR DESCRIPTION
## Summary
- clean up README
- remove duplicate SLURM headers in `downstream_SNP_filtering.sh`
- add missing shebang to `haplotype_phasing_SHAPEIT.sh`

## Testing
- `shellcheck downstream_SNP_filtering.sh haplotype_phasing_SHAPEIT.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842e5d57ef08324bfa0439099cbd112